### PR TITLE
Remove "frontend" from `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Authors@R: c(
            comment = "MathJax library")
     )
 Description: Provides support for building 'pkgdown' websites without an
-    internet connection. Works by bundling cached frontend dependencies and
+    internet connection. Works by bundling cached dependencies and
     implementing drop-in replacements for key 'pkgdown' functions.
     Enables package documentation websites to be built in environments
     where internet access is unavailable or restricted.

--- a/man/pkgdown.offline-package.Rd
+++ b/man/pkgdown.offline-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Provides support for building 'pkgdown' websites without an internet connection. Works by bundling cached frontend dependencies and implementing drop-in replacements for key 'pkgdown' functions. Enables package documentation websites to be built in environments where internet access is unavailable or restricted.
+Provides support for building 'pkgdown' websites without an internet connection. Works by bundling cached dependencies and implementing drop-in replacements for key 'pkgdown' functions. Enables package documentation websites to be built in environments where internet access is unavailable or restricted.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
This PR removes the word "frontend" from `DESCRIPTION` which generates this (false positive) note on win-builder:

> Possibly misspelled words in DESCRIPTION:
>  frontend (27:51)