### PR TITLE
Stub `build_favicons()`

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -16,7 +16,7 @@
 #' pkgdown.offline::init_site()
 #' }
 init_site <- function(...) {
-  version <- packageVersion("pkgdown")
-  copy_to_cache(version)
+  copy_to_cache(packageVersion("pkgdown"))
+  stub_with_null("pkgdown", "build_favicons")
   pkgdown::init_site(...)
 }

--- a/tests/manual/test-build.R
+++ b/tests/manual/test-build.R
@@ -1,13 +1,19 @@
 # Test if offline build works
 
-path <- "zzz.build"
-pkgdown.offline:::install_pkgdown("2.1.2")
-usethis::create_package(path)
+pkgdown_version <- available.packages(repos = "https://cloud.r-project.org/")["pkgdown", "Version"]
+pkgdown.offline:::install_pkgdown(pkgdown_version)
+
+pkg_path <- "zzz.build"
+usethis::create_package(pkg_path)
 
 # Switch off internet connection. In the opened project, run
 usethis::use_pkgdown()
+usethis::use_logo(file.path(R.home(), "doc", "html", "Rlogo.svg"))
+
 pkgdown.offline::clear_cache()
 pkgdown.offline::build_site()
 
+rstudioapi::executeCommand("quitSession")
+
 # In the pkgdown.offline project, clean up
-pkgdown.offline:::dir_delete(path)
+pkgdown.offline:::dir_delete(pkg_path)

--- a/tests/manual/test-init.R
+++ b/tests/manual/test-init.R
@@ -1,13 +1,19 @@
 # Test if offline initialization works
 
-path <- "zzz.init"
-pkgdown.offline:::install_pkgdown("2.1.2")
-usethis::create_package(path)
+pkgdown_version <- available.packages(repos = "https://cloud.r-project.org/")["pkgdown", "Version"]
+pkgdown.offline:::install_pkgdown(pkgdown_version)
+
+pkg_path <- "zzz.init"
+usethis::create_package(pkg_path)
 
 # Switch off internet connection. In the opened project, run
 usethis::use_pkgdown()
+usethis::use_logo(file.path(R.home(), "doc", "html", "Rlogo.svg"))
+
 pkgdown.offline::clear_cache()
 pkgdown.offline::init_site()
 
+rstudioapi::executeCommand("quitSession")
+
 # In the pkgdown.offline project, clean up
-pkgdown.offline:::dir_delete(path)
+pkgdown.offline:::dir_delete(pkg_path)


### PR DESCRIPTION
Fixes #20 

This PR improves `init_site()` by stubbing `build_favicons()` to prevent it from accessing the internet.

Also improves the manual tests by adding a logo to the example package so this logic is covered.