### PR TITLE
Qualify namespace for `install.packages()` to bypass possible RStudio hooks

### DIFF
--- a/tools/tools.R
+++ b/tools/tools.R
@@ -133,11 +133,11 @@ path_cache_dev <- function() {
 #'
 #' @noRd
 install_pkgdown <- function(version) {
-  current_version <- available.packages(repos = "https://cloud.r-project.org/")["pkgdown", "Version"]
+  current_version <- utils::available.packages(repos = "https://cloud.r-project.org/")["pkgdown", "Version"]
   url <- if (version == current_version) {
     paste0("https://cloud.r-project.org/src/contrib/pkgdown_", version, ".tar.gz")
   } else {
     paste0("https://cloud.r-project.org/src/contrib/Archive/pkgdown/pkgdown_", version, ".tar.gz")
   }
-  install.packages(url, repos = NULL)
+  utils::install.packages(url, repos = NULL)
 }


### PR DESCRIPTION
Fixes #34 